### PR TITLE
[deps] Fix "failed to select a version" issues with Aptos cargo deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ hyper = { version = "=1.0.0-rc.3", default-features = false, features = [
 ] }
 nom = "7.1"
 peg = "0.8.1"
-openssl = "^0.10.56"
+openssl = { version = ">=0.10.50, <=0.10.50" }
 rand = "0.8"
 serde = { version = "^1.0.141", features = ["derive"] }
 serde_cbor_2 = { version = "0.12.0-dev" }

--- a/webauthn-rs-core/src/assertion.rs
+++ b/webauthn-rs-core/src/assertion.rs
@@ -43,7 +43,7 @@ type VerificationData = Vec<u8>;
 ///
 /// For more info: https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion
 #[allow(dead_code)]
-pub(crate) fn parse_public_key_credential(
+pub fn parse_public_key_credential(
     rsp: &PublicKeyCredential,
     cose_algorithm: COSEAlgorithm,
 ) -> Result<(VerificationData, Signature), WebauthnError> {

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -562,17 +562,21 @@ impl TryFrom<SerialisableAttestationData> for ParsedAttestationData {
 }
 
 /// Marker type parameter for data related to registration ceremony
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Registration;
 
 /// Marker type parameter for data related to authentication ceremony
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Authentication;
 
 /// Trait for ceremony marker structs
 pub trait Ceremony {
     /// The type of the extension outputs of the ceremony
-    type SignedExtensions: DeserializeOwned + std::fmt::Debug + std::default::Default;
+    type SignedExtensions: std::fmt::Debug
+        + std::default::Default
+        + Clone
+        + Serialize
+        + DeserializeOwned;
 }
 
 impl Ceremony for Registration {
@@ -621,7 +625,7 @@ pub struct AuthenticationSignedExtensions {
 }
 
 /// Attested Credential Data
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttestedCredentialData {
     /// The guid of the authenticator. May indicate manufacturer.
     pub aaguid: Aaguid,

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -5,7 +5,7 @@ use crate::attestation::AttestationFormat;
 use crate::error::WebauthnError;
 use crate::proto::*;
 use base64urlsafedata::Base64UrlSafeData;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use std::borrow::Borrow;
 use std::convert::TryFrom;
@@ -359,7 +359,7 @@ fn authenticator_data_parser<T: Ceremony>(i: &[u8]) -> nom::IResult<&[u8], Authe
 }
 
 /// Data returned by this authenticator during registration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthenticatorData<T: Ceremony> {
     /// Hash of the relying party id.
     pub(crate) rp_id_hash: [u8; 32],
@@ -485,14 +485,21 @@ impl<T: Ceremony> TryFrom<&AuthenticatorAttestationResponseRaw>
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct AuthenticatorAssertionResponse<T: Ceremony> {
-    pub(crate) authenticator_data: AuthenticatorData<T>,
-    pub(crate) authenticator_data_bytes: Vec<u8>,
-    pub(crate) client_data: CollectedClientData,
-    pub(crate) client_data_bytes: Vec<u8>,
-    pub(crate) signature: Vec<u8>,
-    pub(crate) _user_handle: Option<Vec<u8>>,
+/// Authenticator Assertion Response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthenticatorAssertionResponse<T: Ceremony> {
+    /// Authenticator Data Object
+    pub authenticator_data: AuthenticatorData<T>,
+    /// Authenticator Data Bytes
+    pub authenticator_data_bytes: Vec<u8>,
+    /// Client Data Object
+    pub client_data: CollectedClientData,
+    /// Client Data Bytes
+    pub client_data_bytes: Vec<u8>,
+    /// DER Encoded Signature
+    pub signature: Vec<u8>,
+    /// User Handle
+    pub _user_handle: Option<Vec<u8>>,
 }
 
 impl<T: Ceremony> TryFrom<&AuthenticatorAssertionResponseRaw>


### PR DESCRIPTION
# Summary

**The following deps were not compatible with `aptos-labs/aptos-core`, requiring version bumps or locks**
- [x] `openssl`

# Test Plan
Builds when added as a dep to `aptos-core`. Passes all tests on `webauthn-rs` as well.