### PR TITLE
[deps] bump openssl 0.10.56

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ hyper = { version = "=1.0.0-rc.3", default-features = false, features = [
 ] }
 nom = "7.1"
 peg = "0.8.1"
-openssl = { version = ">=0.10.50, <=0.10.50" }
+openssl = { version = ">=0.10.56, <=0.10.56" }
 rand = "0.8"
 serde = { version = "^1.0.141", features = ["derive"] }
 serde_cbor_2 = { version = "0.12.0-dev" }

--- a/webauthn-rs-core/src/assertion.rs
+++ b/webauthn-rs-core/src/assertion.rs
@@ -80,8 +80,8 @@ pub fn parse_public_key_credential(
     match cose_algorithm {
         COSEAlgorithm::ES256 => {
             // Convert the DER, byte encoded signature to a P256Signature that can then be used
-            // to derive the raw, fixed byte length signature. Uses the recommended curve ->
-            // SECP256R1
+            // to derive the raw, fixed byte length signature.
+            // Uses the recommended curve -> SECP256R1
             let fixed_size_p256_signature =
                 p256_der_to_fixed_size_signature(data.signature.as_slice()).map_err(|e| {
                     debug!("p256_der_to_raw_signature -> {:#?}", e);


### PR DESCRIPTION
## Summary
After rebasing `webauthn` branch on latest main, received dependency conflict

```bash
failed to select a version for `openssl`.
    ... required by package `native-tls v0.2.10`
...
versions that meet the requirements `^0.10.29` (locked to 0.10.56) are: 0.10.56

all possible versions conflict with previously selected packages.

  previously selected package `openssl v0.10.50`
    ... which satisfies dependency `openssl = ">=0.10.50, <=0.10.50"` of package `webauthn-rs-core v0.5.0-dev (https://github.com/aptos-labs/webauthn-rs#53e24feb)`
...
```

Same as title

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
