### PR TITLE
[assertion] PartialAuthenticatorAssertionResponse and helper functions

### DIFF
--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -37,6 +37,7 @@ der-parser = "7.0.0"
 compact_jwt.workspace = true
 uuid = { workspace = true, features = ["serde"] }
 p256 = { version = "0.13.2" } #, features = ["serde"] }
+bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/webauthn-rs-core/src/error.rs
+++ b/webauthn-rs-core/src/error.rs
@@ -1,6 +1,7 @@
 //! Possible errors that may occur during Webauthn Operation processing
 
 use base64::DecodeError as b64DecodeError;
+use bcs::Error as BCSError;
 use openssl::error::ErrorStack as OpenSSLErrorStack;
 use serde_cbor_2::error::Error as CBORError;
 use serde_json::error::Error as JSONError;
@@ -162,6 +163,9 @@ pub enum WebauthnError {
     #[error("A base64 parser failure has occurred")]
     ParseBase64Failure(#[from] b64DecodeError),
 
+    #[error("A BCS parser failure has occurred")]
+    ParseBCSFailure(#[from] BCSError),
+
     #[error("A CBOR parser failure has occurred")]
     ParseCBORFailure(#[from] CBORError),
 
@@ -289,6 +293,9 @@ pub enum WebauthnError {
 
     #[error("The attestation requst indicates cred protect was required, but user verification was not performed")]
     SshPublicKeyInconsistentUserVerification,
+
+    #[error("A BCS encoding failure has occurred")]
+    EncodeBCSFailure,
 }
 
 impl PartialEq for WebauthnError {


### PR DESCRIPTION
## Summary
- Instead of parsing a `PublicKeyCredential`, we are parsing a `PartialAuthenticatorAssertionResponseRaw` 
- The `PublicKeyCredential`'s `signature`, `authenticator_data`, and `client_data_json` fields are combined into a vector, in that order, and BCS encoded. The BCS encoded bytes are then used as the `signature` in `SignedTransaction` instead of the `PublicKeyCredential` bytes

## Test plan
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
