### PR TITLE
[webauthn] webauthn-authenticator-rs async-stream dep version change, public functions for testing in Aptos AccountAuthenticator - register_credential_internal and Challenge::new public functions

### DIFF
--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -98,7 +98,7 @@ bitflags = "1.3.2"
 unicode-normalization = "0.1.22"
 num-traits = "0.2"
 num-derive = "0.3"
-async-stream = "0.3.5"
+async-stream = "= 0.3.3"
 async-trait = "0.1.58"
 futures.workspace = true
 

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -335,8 +335,12 @@ impl WebauthnCore {
         Ok(credential)
     }
 
+    /// Register Credential Internal
+    ///
+    /// Converted method from `pub(crate)` to `pub`
+    /// for testing in Aptos' `AccountAuthenticator`.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn register_credential_internal(
+    pub fn register_credential_internal(
         &self,
         reg: &RegisterPublicKeyCredential,
         policy: UserVerificationPolicy,

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -60,6 +60,12 @@ impl AuthenticationState {
     pub fn set_allowed_credentials(&mut self, credentials: Vec<Credential>) {
         self.credentials = credentials;
     }
+
+    /// set the challenge of the authentication state
+    /// Note: added method for easier testing with Aptos AccountAuthenticator
+    pub fn set_challenge(&mut self, challenge: Base64UrlSafeData) {
+        self.challenge = challenge;
+    }
 }
 
 /// An EDDSACurve identifier. You probably will never need to alter

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -26,7 +26,7 @@ pub struct Challenge(Vec<u8>);
 
 impl Challenge {
     /// Creates a new Challenge from a vector of bytes.
-    pub(crate) fn new(challenge: Vec<u8>) -> Self {
+    pub fn new(challenge: Vec<u8>) -> Self {
         Challenge(challenge)
     }
 }


### PR DESCRIPTION
## Summary
- Aptos uses `async-stream` `v0.3.3`, but this webauthn-rs fork was using `v0.3.5`. Downgrading the version here to ensure crate compatibility.
- Need access to methods like `register_credential_internal` from outside of this crate for testing with Aptos `AccountAuthenticator`. Also making `Challenge::new` function `pub` instead of `pub(crate)`

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
